### PR TITLE
Change the logic for the machine label on AIX.

### DIFF
--- a/lib/poise_monit/monit_providers/binaries.rb
+++ b/lib/poise_monit/monit_providers/binaries.rb
@@ -70,7 +70,14 @@ module PoiseMonit
         raw_kernel = (node['kernel']['name'] || 'unknown').downcase
         kernel = case raw_kernel
         when 'aix'
-          "aix#{node['kernel']['version']}.#{node['kernel']['release']}"
+          # Less correct than "aix#{node['kernel']['version']}.#{node['kernel']['release']}"
+          # but more likely to work on more systems. Notably we think the 6.1
+          # build should work on AIX 7 just fine.
+          if node['kernel']['version'].to_i <= 5
+            'aix5.3'
+          else
+            'aix6.1'
+          end
         when 'sunos'
           'solaris'
         when 'darwin'

--- a/test/spec/monit_providers/binaries_spec.rb
+++ b/test/spec/monit_providers/binaries_spec.rb
@@ -71,6 +71,11 @@ describe PoiseMonit::MonitProviders::Binaries do
     it_behaves_like 'binaries provider', 'monit-5.15', 'https://bitbucket.org/tildeslash/monit/downloads/monit-5.15-aix6.1-ppc.tar.gz'
   end # /context on AIX 6
 
+  context 'on AIX 7' do
+    let(:chefspec_options) { {platform: 'aix', version: '7.1'} }
+    it_behaves_like 'binaries provider', 'monit-5.15', 'https://bitbucket.org/tildeslash/monit/downloads/monit-5.15-aix6.1-ppc.tar.gz'
+  end # /context on AIX 7
+
   context 'on Solaris 5.11' do
     let(:chefspec_options) { {platform: 'solaris2', version: '5.11'} }
     it_behaves_like 'binaries provider', 'monit-5.15', 'https://bitbucket.org/tildeslash/monit/downloads/monit-5.15-solaris-x64.tar.gz'

--- a/test/spec/monit_providers/binaries_spec.rb
+++ b/test/spec/monit_providers/binaries_spec.rb
@@ -66,6 +66,13 @@ describe PoiseMonit::MonitProviders::Binaries do
     it_behaves_like 'binaries provider', 'monit-5.15', 'https://bitbucket.org/tildeslash/monit/downloads/monit-5.15-linux-x86.tar.gz'
   end # /context on Fedora 18 (x86)
 
+  context 'on AIX 5' do
+    # Fauxhai doesn't have AIX 5 data, so fake it.
+    let(:chefspec_options) { {platform: 'aix', version: '6.1'} }
+    before { chef_runner.node.automatic['kernel']['version'] = 5 }
+    it_behaves_like 'binaries provider', 'monit-5.15', 'https://bitbucket.org/tildeslash/monit/downloads/monit-5.15-aix5.3-ppc.tar.gz'
+  end # /context on AIX 5
+
   context 'on AIX 6' do
     let(:chefspec_options) { {platform: 'aix', version: '6.1'} }
     it_behaves_like 'binaries provider', 'monit-5.15', 'https://bitbucket.org/tildeslash/monit/downloads/monit-5.15-aix6.1-ppc.tar.gz'


### PR DESCRIPTION
AIX 5 and below get the 5.3 build, everything else uses 6.1. We think
this is correct because 6.1 static binaries should run fine on 7.1.

Closes #3. /cc @johnbellone
