### PR TITLE
remove duplicate call to monit_shell_out! on start_service

### DIFF
--- a/lib/poise_monit/resources/monit_service.rb
+++ b/lib/poise_monit/resources/monit_service.rb
@@ -132,7 +132,6 @@ module PoiseMonit
 
         def start_service
           monit_shell_out!('start')
-          monit_shell_out!('start')
         end
 
         def stop_service


### PR DESCRIPTION
possibly related to https://github.com/poise/poise-monit/issues/6
