### PR TITLE
Adds poise 2.7 as an option for dependency

### DIFF
--- a/poise-monit.gemspec
+++ b/poise-monit.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'chef', '~> 12.1'
   spec.add_dependency 'halite', '~> 1.1'
-  spec.add_dependency 'poise', '~> 2.6'
+  spec.add_dependency 'poise', '>= 2.6', '< 2.8'
   spec.add_dependency 'poise-languages', '~> 2.0'
   spec.add_dependency 'poise-service', '~> 1.1'
 


### PR DESCRIPTION
I am running into an issue getting latest `poise-monit` and latest `poise-python` to be compatible in the same run-list, with `poise-python` dependency pointing to `poise` 2.7 and `poise-monit` pointing to 2.6

Here, I am adding 2.7 as an option in the gemspec.

If this is the wrong approach, feel free to let me know a preferred solution.