### PR TITLE
Fixing typo in docstring

### DIFF
--- a/lib/poise_monit/monit_providers/base.rb
+++ b/lib/poise_monit/monit_providers/base.rb
@@ -50,7 +50,7 @@ module PoiseMonit
         super
       end
 
-      # The `enable` action for the `monit` resource.
+      # The `disable` action for the `monit` resource.
       #
       # @return [void]
       def action_disable


### PR DESCRIPTION
disable instead of enable